### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ template:
          - variables:
              entity: >
                 {{ states.media_player | selectattr('name', 'eq', option.split(' ~ ')[0])
-                |map(attribute='entity_id')|join }}
+                |map(attribute='entity_id')|first }}
          - service: input_text.set_value
            target:
              entity_id: input_text.selected_media_player 


### PR DESCRIPTION
Changes 

|map(attribute='entity_id')|join }}

To 
 |map(attribute='entity_id')|first

In case you have more then 1 media player  with exact same friendly_name  it will pick the first one matching that name  , with old join it whould fail as the 2 entity id's whould just concatenate resulting in an error, 

However,  it's bad practice to have 2 entities with same name, 